### PR TITLE
Fix typo in flip sign comments

### DIFF
--- a/CoreOperation.c
+++ b/CoreOperation.c
@@ -402,7 +402,7 @@ int big_get_sign(bigint* x) {
 	return (x->sign);
 }
 /**
- * filp sign of bigint.
+ * flip sign of bigint.
  *
  * \param x : bigint (can't be NULL)
  * \return : ErrorMessage

--- a/CoreOperation.h
+++ b/CoreOperation.h
@@ -46,7 +46,7 @@ ErrorMessage big_assign(bigint** dst, bigint* src);
 // generate random bigint x
 ErrorMessage big_gen_rand(bigint** x, int sign, int wordlen);
 
-// filp sign of bigint x to inverse
+// flip sign of bigint x to inverse
 ErrorMessage big_flip_sign(bigint** x);
 
 // compare x with y (1 = x is bigger, 0 = two numbers are equal, -1 = y is bigger)


### PR DESCRIPTION
## Summary
- fix 'filp' typo in big integer sign flip comments

## Testing
- `gcc -std=c11 -Wall -Wextra *.c -lm -o big_test`

------
https://chatgpt.com/codex/tasks/task_e_68997f32f18c832fb38b398ebd797a5c