### PR TITLE
Restrict hexadecimal parsing to valid digits

### DIFF
--- a/BasicOperation.c
+++ b/BasicOperation.c
@@ -65,46 +65,51 @@ char digit2char(word a)
 }
 unsigned int hex2int(char c)
 {
-	if (c >= 'a' && c <= 'z')
-	{
-		return (int)c - 'a' + 10;
-	}
-	else if (c >= 'A' && c <= 'Z')
-	{
-		return (int)c - 'A' + 10;
-	}
-	else if (c >= '0' && c <= '9')
-	{
-		return (int)c - '0';
-	}
-	else
-	{
-		return 0;
-	}
+        if (c >= 'a' && c <= 'f')
+        {
+                return (unsigned int)c - 'a' + 10;
+        }
+        else if (c >= 'A' && c <= 'F')
+        {
+                return (unsigned int)c - 'A' + 10;
+        }
+        else if (c >= '0' && c <= '9')
+        {
+                return (unsigned int)c - '0';
+        }
+        else
+        {
+                return 0;
+        }
 }
 bool isValidChar(char c, int base)
 {
-	if (base == 2)
-	{
-		if (c != '0' && c != '1')
-			return false;
-	}
-	else if (base == 10)
-	{
-		if (!(c >= '0' && c <= '9'))
-			return false;
-	}
-	else if (base == 16)
-	{
-		if (c >= 'a' && c <= 'z') {}
-		else if (c >= 'A' && c <= 'Z') {}
-		else if (c >= '0' && c <= '9') {}
-		else
-			return false;
-	}
-	else
-		return false;
-	return true;
+        if (base == 2)
+        {
+                if (c != '0' && c != '1')
+                        return false;
+        }
+        else if (base == 10)
+        {
+                if (!(c >= '0' && c <= '9'))
+                        return false;
+        }
+        else if (base == 16)
+        {
+                if ((c >= 'a' && c <= 'f') ||
+                    (c >= 'A' && c <= 'F') ||
+                    (c >= '0' && c <= '9'))
+                {
+                        /* valid hexadecimal character */
+                }
+                else
+                {
+                        return false;
+                }
+        }
+        else
+                return false;
+        return true;
 }
 
 ErrorMessage wordMultiplication(word* C1, word* C0, word A, word B)


### PR DESCRIPTION
## Summary
- Limit `hex2int` to only accept 0-9 and A-F/a-f
- Tighten `isValidChar` check for hexadecimal strings to reject non-hex letters

## Testing
- `gcc main.c test.c BasicOperation.c CoreOperation.c RSA.c ErrorMessage.c -lm -o main`
- `printf "0\n" | ./main`
- `gcc hex_test.c BasicOperation.c CoreOperation.c RSA.c ErrorMessage.c -lm -o hex_test`
- `./hex_test`


------
https://chatgpt.com/codex/tasks/task_e_68997e359398832f99f64564a5520c16